### PR TITLE
Use bulk inserts.

### DIFF
--- a/test_subsetter.py
+++ b/test_subsetter.py
@@ -9,15 +9,16 @@ class DummyArgs(object):
     fraction = 0.25
     force_rows = {}
     children = 25
+    buffer = 1000
 
 dummy_args = DummyArgs()
 
 class OverallTest(unittest.TestCase):
-   
+
     def setUp(self):
         schema = ["CREATE TABLE state (abbrev, name)",
-                  """CREATE TABLE city (name, state_abbrev, 
-                                        FOREIGN KEY (state_abbrev) 
+                  """CREATE TABLE city (name, state_abbrev,
+                                        FOREIGN KEY (state_abbrev)
                                         REFERENCES state(abbrev))""",
                   """CREATE TABLE landmark (name, city,
                                             FOREIGN KEY (city)
@@ -36,13 +37,13 @@ class OverallTest(unittest.TestCase):
         for statement in schema:
             self.source_db.execute(statement)
             self.dest_db.execute(statement)
-        for params in (('MN', 'Minnesota'), ('OH', 'Ohio'), 
+        for params in (('MN', 'Minnesota'), ('OH', 'Ohio'),
                        ('MA', 'Massachussetts'), ('MI', 'Michigan')):
             self.source_db.execute("INSERT INTO state VALUES (?, ?)", params)
-        for params in (('Duluth', 'MN'), ('Dayton', 'OH'), 
+        for params in (('Duluth', 'MN'), ('Dayton', 'OH'),
                        ('Boston', 'MA'), ('Houghton', 'MI')):
             self.source_db.execute("INSERT INTO city VALUES (?, ?)", params)
-        for params in (('Lift Bridge', 'Duluth'), ("Mendelson's", 'Dayton'), 
+        for params in (('Lift Bridge', 'Duluth'), ("Mendelson's", 'Dayton'),
                        ('Trinity Church', 'Boston'), ('Michigan Tech', 'Houghton')):
             self.source_db.execute("INSERT INTO landmark VALUES (?, ?)", params)
         for params in (('Graf Zeppelin', None), ('USS Los Angeles', None),
@@ -50,7 +51,7 @@ class OverallTest(unittest.TestCase):
             self.source_db.execute("INSERT INTO zeppelins VALUES (?, ?)", params)
         self.source_db.commit()
         self.dest_db.commit()
-    
+
     def tearDown(self):
         self.source_db.close()
         os.unlink(self.source_db_filename)
@@ -65,11 +66,11 @@ class OverallTest(unittest.TestCase):
         cities = self.dest_db.execute("SELECT * FROM city").fetchall()
         self.assertEqual(len(cities), 1)
         joined = self.dest_db.execute("""SELECT c.name, s.name
-                                         FROM city c JOIN state s 
+                                         FROM city c JOIN state s
                                                      ON (c.state_abbrev = s.abbrev)""")
         joined = joined.fetchall()
         self.assertEqual(len(joined), 1)
-             
+
     def test_null_foreign_keys(self):
         src = Db(self.source_sqla, dummy_args)
         dest = Db(self.dest_sqla, dummy_args)
@@ -77,4 +78,3 @@ class OverallTest(unittest.TestCase):
         src.create_subset_in(dest)
         zeppelins = self.dest_db.execute("SELECT * FROM zeppelins").fetchall()
         self.assertEqual(len(zeppelins), 1)
-       


### PR DESCRIPTION
The subsetter spends a significant chunk of overall running time on
single-row inserts into the destination tables. This patch accumulates
rows in the `pending` attribute on each table, then periodically flushes
updates to the database when the number of accumulated rows exceeds the
`buffer` argument. Depending on the value of `buffer`, this change
reduced running time by 20-30% on a sample database.

This change assumes that `rdbms-subset` is run against an empty destination database--if this isn't the case, the existence check on line 242 can be incorrect, since it isn't actually making a call to the database (which also saves a lot of time!). I can revise the patch to load existing primary keys from the destination database before inserting, which I think would take care of this potential issue.