### PR TITLE
Allow specification of quasi-foreign keys in config file.

### DIFF
--- a/subsetter.py
+++ b/subsetter.py
@@ -58,6 +58,7 @@ supported).
 Case-specific table names will probably create bad results in rdbms-subsetter,
 and in the rest of your life, for that matter.  Don't do it.
 """
+import json
 import argparse
 import logging
 from collections import OrderedDict, deque
@@ -193,7 +194,8 @@ class Db(object):
             tbl.find_n_rows(estimate=True)
             self.tables[(tbl.schema, tbl.name)] = tbl
         for ((tbl_schema, tbl_name), tbl) in self.tables.items():
-            for fk in tbl.fks:
+            constraints = args.config.get('constraints', {}).get(tbl_name, [])
+            for fk in (tbl.fks + constraints):
                 fk['constrained_schema'] = tbl_schema
                 fk['constrained_table'] = tbl_name  # TODO: check against constrained_table
                 self.tables[(fk['referred_schema'], fk['referred_table'])].child_fks.append(fk)
@@ -380,6 +382,8 @@ argparser.add_argument('-c', '--children',
                        type=int, default=3)
 argparser.add_argument('--schema', help='Non-default schema to include',
                        type=str, action='append', default=[])
+argparser.add_argument('--config', help='Path to configuration .json file',
+                       type=argparse.FileType('r'))
 argparser.add_argument('-y', '--yes', help='Proceed without stopping for confirmation', action='store_true')
 
 def generate():
@@ -392,6 +396,7 @@ def generate():
         args.force_rows[table_name].append(pk)
     logging.getLogger().setLevel(args.loglevel)
     schemas = args.schema + [None,]
+    args.config = json.load(args.config) if args.config else {}
     for schema in schemas:
         source = Db(args.source, args, schema=schema)
         target = Db(args.dest, args, schema=schema)

--- a/test_subsetter.py
+++ b/test_subsetter.py
@@ -9,6 +9,7 @@ class DummyArgs(object):
     fraction = 0.25
     force_rows = {}
     children = 25
+    config = {}
 
 dummy_args = DummyArgs()
 


### PR DESCRIPTION
This may be too much of an edge case to merge, but here goes. Some databases may have quasi-foreign key relations, where no foreign key constraint is declared, but a column in one table still refers to primary keys in another table. In that case, it's helpful to be able to manually specify a set of additional foreign key relationships that the subsetter should respect. This patch adds an optional command line argument called `--config` that can point to a JSON file. The `constraints` field of that file, if it exists, is inspected for additional quasi-foreign key relationships--example at https://github.com/jmcarp/openFEC/blob/feature/auto-subset/data/subset-config.json.