### PR TITLE
Publish cleanup

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,6 @@
+# Packaging
+twine
+wheel
+
+# Testing
+nosetests

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,9 @@ setup(
     long_description=readme,
     author='Catherine Devlin',
     author_email='catherine.devlin@gsa.gov',
-    url='https://github.com/18f/https://github.com/18F/rdbms-subsetter',
+    url='https://github.com/18F/rdbms-subsetter',
     install_requires=[
-      "sqlalchemy",
+        "sqlalchemy",
     ],
     license="CC0",
     keywords='database testing',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,15 @@ except ImportError:
     from distutils.core import setup
 
 if sys.argv[-1] == 'publish':
-    os.system('python setup.py sdist upload')
+    # Clean existing build artifacts
+    os.system('rm -rf dist')
+    os.system('rm -rf build')
+    os.system('rm -rf rdbms_subsetter.egg-info')
+
+    # Build and publish
+    os.system('python setup.py sdist bdist_wheel')
+    os.system('twine upload dist/*')
+
     sys.exit()
 
 curdir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
A few drive-by patches:

a1a242f
* Fix package URL

6dc92ba
* List development requirements explicitly
* Use twine to publish build artifacts to PyPI
* Build wheels as well as source distribution

Why twine: https://github.com/pypa/twine#why-should-i-use-this
Why wheel: http://pythonwheels.com/

I often use some packaging snippets from a friend's libraries (e.g. https://github.com/sloria/webargs/blob/dev/tasks.py#L88-L97). I would've suggested this here, but didn't want to add extra requirements (invoke).

Also, looks like it's time publish 0.2.4!