### PR TITLE
Event handling with blinker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,44 @@ in JSON.  For example,
       }
     }
 
+Signal handlers
+---------------
+If you provide a python module with appropriate signal handling functions, and specify that module
+when calling the script like ``--import=my.signals.signal_handlers``, then any signal handlers that you
+have registered in your module will be called when the corresponding signals are sent during
+the DB subsetting process.
+
+At the moment, the only signal is ``subsetter.SIGNAL_ROW_ADDED``.
+
+An example signal handling module::
+
+  from blinker import signal
+  import subsetter
+
+  row_added_signal = signal(subsetter.SIGNAL_ROW_ADDED)
+  @row_added_signal.connect
+  def row_added(source_db, **kwargs):
+     print("row_added called with source db: {}, and kwargs: {}".format(source_db, kwargs))
+
+SIGNAL_ROW_ADDED
+^^^^^^^^^^^^^^^^
+This signal will be sent when a new row has been selected for adding to the target database.
+The associated signal handler should have the following signature::
+
+    def row_added(source_db, **kwargs):
+
+``source_db`` is a ``subsetter.Db`` instance.
+
+``kwargs`` contains:
+
+- ``target_db``: a ``subsetter.Db`` instances.
+
+- ``source_row``: an ``sqlalchemy.engine.RowProxy`` with the values from the row that will be inserted.
+
+- ``target_table``: an ``sqlalchemy.Table``.
+
+- ``prioritized``: a ``bool`` representing whether of not all child, grandchild, etc. rows should be included.
+
 Installing
 ----------
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     url='https://github.com/18f/https://github.com/18F/rdbms-subsetter',
     install_requires=[
       "sqlalchemy",
+      "blinker",
     ],
     license="CC0",
     keywords='database testing',

--- a/subsetter.py
+++ b/subsetter.py
@@ -67,6 +67,7 @@ from collections import OrderedDict, deque
 import math
 import random
 import types
+from blinker import signal
 import sqlalchemy as sa
 from sqlalchemy.engine.reflection import Inspector
 
@@ -165,6 +166,11 @@ def _completeness_score(self):
     if not self.required:  # anything in `required` queue disqualifies
         result += (self.n_rows / (self.n_rows_desired or 1))**0.33
     return result
+
+def _import_modules(import_list):
+    for module_name in import_list:
+        __import__(module_name)
+
 
 class Db(object):
 
@@ -422,10 +428,14 @@ argparser.add_argument('--exclude-table', '-T', dest='exclude_tables', help='Tab
                        type=str, action='append', default=[])
 argparser.add_argument('--full-table', '-F', dest='full_tables', help='Tables to include every row of',
                        type=str, action='append', default=[])
+argparser.add_argument('--import', '-i', dest='import_list',
+                       help='Dotted module name to import; e.g. custom.signalhandler',
+                       type=str, action='append', default=[])
 argparser.add_argument('-y', '--yes', help='Proceed without stopping for confirmation', action='store_true')
 
 def generate():
     args = argparser.parse_args()
+    _import_modules(args.import_list)
     args.force_rows = {}
     for force_row in (args.force or []):
         (table_name, pk) = force_row.split(':')

--- a/subsetter.py
+++ b/subsetter.py
@@ -79,6 +79,8 @@ except NameError:
 
 __version__ = '0.2.4'
 
+SIGNAL_ROW_ADDED = 'row_added'
+
 def _find_n_rows(self, estimate=False):
     self.n_rows = 0
     if estimate:
@@ -285,6 +287,9 @@ class Db(object):
             pks = tuple((source_row[key] for key in target.pk))
             target.pending[pks] = source_row
             target.n_rows += 1
+
+            signal(SIGNAL_ROW_ADDED).send(self, source_row=source_row, target_db=target_db, target_table=target,
+                                          prioritized=prioritized)
 
         for child_fk in target.child_fks:
             child = self.tables[(child_fk['constrained_schema'], child_fk['constrained_table'])]


### PR DESCRIPTION
This will resolve #29, and is meant to replace pull request #30 , where the good suggestion was made to use blinker for handling signals.

Again, here's an example of how I'm using it:
```
from blinker import signal
import sqlalchemy as sa
import subsetter

# This signal handler is triggered by the rdbms-subsetter script;
# it is used here to ensure that when a row from a versioned
# table is added to the subset db, all past/future versions
# of that obect are also added.
row_added_signal = signal(subsetter.SIGNAL_ROW_ADDED)
@row_added_signal.connect
def row_added(source_db, source_row=None, target_db=None, target_table=None, prioritized=False):
    # Nothing to do unless this is a versioned table.
    if 'version_start_date' not in source_row:
        return

    # Add all previous / future versions.
    has_previous_versions = source_row.version_start_date != source_row.version_birth_date
    has_future_versions = source_row.version_end_date is not None and source_row.id != source_row.identity
    if has_previous_versions or has_future_versions:
	versions_select = sa.sql.select([target_table]).where(sa.and_(target_table.c.identity == source_row.identity, target_table.c.id != source_row.id))
	for version_row in source_db.conn.execute(versions_select):
	    source_db.create_row_in(version_row, target_db, target_table)
```