### PR TITLE
Fix incorrect qualified table name building

### DIFF
--- a/rdbms_subsetter/subsetter.py
+++ b/rdbms_subsetter/subsetter.py
@@ -176,7 +176,7 @@ def _by_pk(self, pk):
 
 def _completeness_score(self):
     """Scores how close a target table is to being filled enough to quit"""
-    table = (self.schema if self.schema else "") + self.name
+    table = (self.schema + '.' if self.schema else "") + self.name
     fetch_all = self.fetch_all
     requested = len(self.requested)
     required = len(self.required)


### PR DESCRIPTION
Currently builds the name as "schematable" instead of "schema.table".
Since this is done in multiple places, it could still benefit from a helper function that always does it right.